### PR TITLE
Add Tag Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ $post = \potibm\Bluesky\Feed\Post::create('✨ example mentioning @atproto.com t
 $post = $postService->addFacetsFromMentionsAndLinks($post);
 ```
 
+### Adding mentions and links and tags from post text
+
+```
+$post = \potibm\Bluesky\Feed\Post::create('✨ example mentioning @atproto.com to share the URL 👨‍❤️‍👨 https://en.wikipedia.org/wiki/CBOR. and #HashtagFun');
+$post = $postService->addFacetsFromMentionsAndLinksAndTags($post);
+```
+
 ### Adding images
 
 [https://atproto.com/blog/create-post#images-embeds](https://atproto.com/blog/create-post#images-embeds)

--- a/src/BlueskyPostService.php
+++ b/src/BlueskyPostService.php
@@ -91,7 +91,7 @@ class BlueskyPostService
         return $resultPost;
     }
 
-	public function addFacetsFromTags(Post $post)
+	public function addFacetsFromTags(Post $post): Post
 	{
 		$resultPost = clone $post;
 

--- a/src/BlueskyPostService.php
+++ b/src/BlueskyPostService.php
@@ -12,6 +12,7 @@ use potibm\Bluesky\Feed\Post;
 use potibm\Bluesky\Response\UploadBlobResponse;
 use potibm\Bluesky\Richtext\FacetLink;
 use potibm\Bluesky\Richtext\FacetMention;
+use potibm\Bluesky\Richtext\FacetTag;
 
 class BlueskyPostService
 {
@@ -35,6 +36,14 @@ class BlueskyPostService
 
         return $resultPost;
     }
+
+	public function addFacetsFromMentionsAndLinksAndTags(Post $post): Post
+	{
+		$resultPost = $this->addFacetsFromMentionsAndLinks($post);
+		$resultPost = $this->addFacetsFromTags($resultPost);
+
+		return $resultPost;
+	}
 
     public function addFacetsFromMentions(Post $post): Post
     {
@@ -81,6 +90,27 @@ class BlueskyPostService
 
         return $resultPost;
     }
+
+	public function addFacetsFromTags(Post $post)
+	{
+		$resultPost = clone $post;
+
+		preg_match_all('/(#\w+)/u', $post->getText(), $matches, PREG_OFFSET_CAPTURE);
+		foreach ($matches[0] as $match) {
+			$hashtag = $match[0];
+			$start = $match[1];
+
+			$facet = FacetTag::create(
+				str_replace('#', '', $hashtag),
+				$start,
+				$start + strlen($hashtag)
+			);
+
+			$resultPost->addFacet($facet);
+		}
+
+		return $resultPost;
+	}
 
     public function addQuote(Post $post, string $quotedRecordUri): Post
     {

--- a/src/Richtext/FacetTag.php
+++ b/src/Richtext/FacetTag.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace potibm\Bluesky\Richtext;
+
+class FacetTag extends AbstractFacet
+{
+	private string $tag = '';
+
+	public function __construct()
+	{
+	}
+
+	public function getTag(): string
+	{
+		return $this->tag;
+	}
+
+	public function setTag(string $tag): void
+	{
+		$this->tag = $tag;
+	}
+
+	protected function getFeature(): array
+	{
+		return [
+			'$type' => parent::TYPE . '#tag',
+			"tag" => $this->tag,
+		];
+	}
+
+	public static function create(string $tag, int $start, int $end): self
+	{
+		$link = new self();
+		$link->setStart($start);
+		$link->setEnd($end);
+		$link->setTag($tag);
+		return $link;
+	}
+}

--- a/tests/BlueskyPostServiceTest.php
+++ b/tests/BlueskyPostServiceTest.php
@@ -22,6 +22,7 @@ use potibm\Bluesky\Response\ResponseTrait;
 use potibm\Bluesky\Richtext\AbstractFacet;
 use potibm\Bluesky\Richtext\FacetLink;
 use potibm\Bluesky\Richtext\FacetMention;
+use potibm\Bluesky\Richtext\FacetTag;
 use potibm\Bluesky\Test\Response\RecordResponseTest;
 
 #[CoversClass(BlueskyPostService::class)]
@@ -38,7 +39,7 @@ use potibm\Bluesky\Test\Response\RecordResponseTest;
 class BlueskyPostServiceTest extends TestCase
 {
     private const SAMPLE = '✨ example mentioning @atproto.com ' .
-        'to share the URL 👨‍❤️‍👨 https://en.wikipedia.org/wiki/CBOR.';
+        'to share the URL 👨‍❤️‍👨 https://en.wikipedia.org/wiki/CBOR. and a #HashtagFun.';
 
     private BlueskyPostService $postService;
 
@@ -81,6 +82,22 @@ class BlueskyPostServiceTest extends TestCase
         $this->assertEquals(108, $firstFacet->getEnd());
     }
 
+	public function testTagFacet(): void
+	{
+		/** @psalm-suppress PossiblyNullArgument, PossiblyNullReference */
+		$resultPost = $this->postService->addFacetsFromTags($this->post);
+
+		$this->assertCount(1, $resultPost->getFacets());
+		$this->assertInstanceOf(FacetTag::class, $resultPost->getFacets()[0]);
+		/**
+		 * @var FacetTag $firstFacet
+		 */
+		$firstFacet = $resultPost->getFacets()[0];
+		$this->assertEquals('HashtagFun', $firstFacet->getTag());
+		$this->assertEquals(116, $firstFacet->getStart());
+		$this->assertEquals(127, $firstFacet->getEnd());
+	}
+
     public function testLinkAndMentionFacets(): void
     {
         /** @psalm-suppress PossiblyNullArgument, PossiblyNullReference */
@@ -90,6 +107,17 @@ class BlueskyPostServiceTest extends TestCase
         $this->assertInstanceOf(FacetMention::class, $resultPost->getFacets()[0]);
         $this->assertInstanceOf(FacetLink::class, $resultPost->getFacets()[1]);
     }
+
+	public function testLinkAndMentionAndTagFacets(): void
+	{
+		/** @psalm-suppress PossiblyNullArgument, PossiblyNullReference */
+		$resultPost = $this->postService->addFacetsFromMentionsAndLinksAndTags($this->post);
+
+		$this->assertCount(3, $resultPost->getFacets());
+		$this->assertInstanceOf(FacetMention::class, $resultPost->getFacets()[0]);
+		$this->assertInstanceOf(FacetLink::class, $resultPost->getFacets()[1]);
+		$this->assertInstanceOf(FacetTag::class, $resultPost->getFacets()[2]);
+	}
 
     public function testAddImage(): void
     {

--- a/tests/BlueskyPostServiceTest.php
+++ b/tests/BlueskyPostServiceTest.php
@@ -30,6 +30,7 @@ use potibm\Bluesky\Test\Response\RecordResponseTest;
 #[UsesClass(AbstractFacet::class)]
 #[UsesClass(FacetLink::class)]
 #[UsesClass(FacetMention::class)]
+#[UsesClass(FacetTag::class)]
 #[UsesClass(Images::class)]
 #[UsesClass(External::class)]
 #[UsesClass(BlueskyUri::class)]

--- a/tests/Richtext/FaceTagTest.php
+++ b/tests/Richtext/FaceTagTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Richtext;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use potibm\Bluesky\Richtext\AbstractFacet;
+use potibm\Bluesky\Richtext\FacetTag;
+
+#[CoversClass(FacetTag::class)]
+#[CoversClass(AbstractFacet::class)]
+class FaceTagTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $tag = FacetTag::create('mytag', 5, 16);
+
+        $this->assertEquals('mytag', $tag->getTag());
+        $this->assertEquals(5, $tag->getStart());
+        $this->assertEquals(16, $tag->getEnd());
+
+        $this->assertEquals(
+            [
+                'index' =>
+                            [
+                                'byteStart' => 5,
+                                'byteEnd' => 16,
+                            ],
+                'features' =>
+                    [
+
+                        [
+                            '$type' => 'app.bsky.richtext.facet#tag',
+                            'tag' => 'mytag',
+                        ],
+
+                    ],
+            ],
+            $tag->jsonSerialize()
+        );
+    }
+
+    public function testModifyTag(): void
+    {
+        $tag = new FacetTag();
+        $tag->setTag('mynewtag');
+        $this->assertEquals('mynewtag', $tag->getTag());
+    }
+}


### PR DESCRIPTION
- Added test for FacetTag
- Updated post service test
- Updated readme
- Add two new methods: `addFacetsFromTags` and `addFacetsFromMentionsAndLinksAndTags`

I'm not sure how you want to handle this. Right now I've added new methods as to not break existing installs and keep the existing methods. The cleaner way would be to bump a major version and remove/rename the old `addFacetsFromMentionsAndLinks` method.

Let me know and I'm happy to update if need be.

I have been using my version of this code on [EchoFeed](https://echofeed.app) and it's been working very well. This is a complete copy of what I have there.