### PR TITLE
Specify UTC time for post creation

### DIFF
--- a/src/Feed/Post.php
+++ b/src/Feed/Post.php
@@ -47,7 +47,7 @@ class Post implements JsonSerializable
 
     public function setCreatedAt(\DateTimeImmutable $createdAt): void
     {
-        $this->createdAt = $createdAt;
+        $this->createdAt = $createdAt->setTimezone(new \DateTimeZone('UTC'));
     }
 
     public function getFacets(): array

--- a/src/Feed/Post.php
+++ b/src/Feed/Post.php
@@ -27,7 +27,7 @@ class Post implements JsonSerializable
 
     public function __construct()
     {
-        $this->createdAt = new \DateTimeImmutable();
+        $this->createdAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
     }
 
     public function getText(): string


### PR DESCRIPTION
How would you feel about using [gmdate()](https://www.php.net/manual/en/function.gmdate.php)? I'm not sure the purpose of DateTime _Immutable_.

If you would like to keep DateTime (Immutable or otherwise), we'll need to add the UTC time zone as seen in this PR. If the script/server time is not UTC, the post will be in the past or future, because the output format is simply adding `Z` (Zulu/UTC) to the local DateTime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured that the `createdAt` timestamp for new posts is consistently set to UTC.

- **Chores**
	- Updated the handling of the `createdAt` property in the `Post` class to enhance timestamp accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->