### PR TITLE
Param strict typing should use the interface

### DIFF
--- a/src/BlueskyPostService.php
+++ b/src/BlueskyPostService.php
@@ -23,7 +23,7 @@ class BlueskyPostService
         '[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~\#?&//=]*[-a-zA-Z0-9@%_\+~\#//=])?';
 
     public function __construct(
-        private BlueskyApi $blueskyClient
+        private BlueskyApiInterface $blueskyClient
     ) {
     }
 


### PR DESCRIPTION
In my app, PHPStan complains about using the concrete class instead of interface