### PR TITLE
Add automatic aspectRatio support for image embeds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php-http/discovery": "^1.19"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10",
+    "phpunit/phpunit": "^10.5",
     "nyholm/psr7": "^1.8",
     "symfony/http-client": "^7.0",
     "symplify/easy-coding-standard": "^12.0.8",

--- a/src/BlueskyPostService.php
+++ b/src/BlueskyPostService.php
@@ -140,9 +140,16 @@ class BlueskyPostService
         return $resultPost;
     }
 
-    public function addImage(Post $post, string $imageFile, string $altText): Post
+    public function addImage(Post $post, string $imageFile, string $altText, ?array $aspectRatio = null): Post
     {
         $blob = $this->createBlobFromFilename($imageFile);
+
+        if ($aspectRatio === null && file_exists($imageFile)) {
+            [$width, $height] = getimagesize($imageFile);
+            if ($width > 0 && $height > 0) {
+                $aspectRatio = ['width' => $width, 'height' => $height];
+            }
+        }
 
         $resultPost = clone $post;
         $embed = $resultPost->getEmbed();
@@ -150,7 +157,7 @@ class BlueskyPostService
             $embed = new Images();
             $resultPost->setEmbed($embed);
         }
-        $embed->addImage($blob, $altText);
+        $embed->addImage($blob, $altText, $aspectRatio);
 
         return $resultPost;
     }

--- a/src/BlueskyPostService.php
+++ b/src/BlueskyPostService.php
@@ -13,6 +13,7 @@ use potibm\Bluesky\Response\UploadBlobResponse;
 use potibm\Bluesky\Richtext\FacetLink;
 use potibm\Bluesky\Richtext\FacetMention;
 use potibm\Bluesky\Richtext\FacetTag;
+use potibm\Bluesky\Embed\AspectRatio;
 
 class BlueskyPostService
 {
@@ -140,14 +141,14 @@ class BlueskyPostService
         return $resultPost;
     }
 
-    public function addImage(Post $post, string $imageFile, string $altText, ?array $aspectRatio = null): Post
+    public function addImage(Post $post, string $imageFile, string $altText, ?AspectRatio $aspectRatio = null): Post
     {
         $blob = $this->createBlobFromFilename($imageFile);
 
-        if ($aspectRatio === null && file_exists($imageFile)) {
-            [$width, $height] = getimagesize($imageFile);
-            if ($width > 0 && $height > 0) {
-                $aspectRatio = ['width' => $width, 'height' => $height];
+        if ($aspectRatio === null) {
+            $size = @getimagesize($imageFile);
+            if ($size !== false) {
+                $aspectRatio = new AspectRatio($size[0], $size[1]);
             }
         }
 

--- a/src/Embed/AspectRatio.php
+++ b/src/Embed/AspectRatio.php
@@ -1,0 +1,22 @@
+<?php
+namespace potibm\Bluesky\Embed;
+
+class AspectRatio
+{
+    public int $width;
+    public int $height;
+
+    public function __construct(int $width, int $height)
+    {
+        $this->width = $width;
+        $this->height = $height;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'width' => $this->width,
+            'height' => $this->height,
+        ];
+    }
+}

--- a/src/Embed/Images.php
+++ b/src/Embed/Images.php
@@ -10,12 +10,21 @@ class Images implements Embeddable, \Countable
 {
     private array $images = [];
 
-    public function addImage(UploadBlobResponse $image, string $alt = ''): void
+    public function addImage(UploadBlobResponse $image, string $alt = '', ?array $aspectRatio = null): void
     {
-        $this->images[] = [
+        $imageData = [
             'alt' => $alt,
             'image' => $image,
         ];
+
+        if ($aspectRatio && isset($aspectRatio['width'], $aspectRatio['height'])) {
+            $imageData['aspectRatio'] = [
+                'width' => (int)$aspectRatio['width'],
+                'height' => (int)$aspectRatio['height'],
+            ];
+        }
+
+        $this->images[] = $imageData;
     }
 
     public function clearImages(): void

--- a/src/Embed/Images.php
+++ b/src/Embed/Images.php
@@ -17,7 +17,7 @@ class Images implements Embeddable, \Countable
             'image' => $image,
         ];
 
-        if ($aspectRatio && isset($aspectRatio['width'], $aspectRatio['height'])) {
+        if ($aspectRatio !== null) {
             $imageData['aspectRatio'] = $aspectRatio->toArray();
         }
 

--- a/src/Embed/Images.php
+++ b/src/Embed/Images.php
@@ -10,7 +10,7 @@ class Images implements Embeddable, \Countable
 {
     private array $images = [];
 
-    public function addImage(UploadBlobResponse $image, string $alt = '', ?array $aspectRatio = null): void
+    public function addImage(UploadBlobResponse $image, string $alt = '', ?aspectRatio $aspectRatio = null): void
     {
         $imageData = [
             'alt' => $alt,
@@ -18,10 +18,7 @@ class Images implements Embeddable, \Countable
         ];
 
         if ($aspectRatio && isset($aspectRatio['width'], $aspectRatio['height'])) {
-            $imageData['aspectRatio'] = [
-                'width' => (int)$aspectRatio['width'],
-                'height' => (int)$aspectRatio['height'],
-            ];
+            $imageData['aspectRatio'] = $aspectRatio->toArray();
         }
 
         $this->images[] = $imageData;

--- a/tests/Embed/AspectRatioTest.php
+++ b/tests/Embed/AspectRatioTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace potibm\Bluesky\Test\Embed;
+
+use PHPUnit\Framework\TestCase;
+use potibm\Bluesky\Embed\AspectRatio;
+
+#[\PHPUnit\Framework\Attributes\CoversClass(AspectRatio::class)]
+class AspectRatioTest extends TestCase
+{
+    public function testAspectRatioInitialization()
+    {
+        $ar = new AspectRatio(800, 600);
+
+        $this->assertEquals(800, $ar->width);
+        $this->assertEquals(600, $ar->height);
+    }
+
+    public function testToArray()
+    {
+        $ar = new AspectRatio(1920, 1080);
+        $this->assertEquals([
+            'width' => 1920,
+            'height' => 1080,
+        ], $ar->toArray());
+    }
+}


### PR DESCRIPTION
This PR adds support for automatically setting the `aspectRatio` field when embedding images in Bluesky posts.  
It uses `getimagesize()` to extract image dimensions from local files before uploading.

This improves display accuracy for non-square images.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Images added to posts now automatically include aspect ratio information when available, improving display accuracy.
- **Enhancements**
  - Improved handling of image dimensions for embedded images in posts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->